### PR TITLE
Fixes for RB -> Amarok

### DIFF
--- a/dumprhythm.py
+++ b/dumprhythm.py
@@ -39,7 +39,7 @@ class RhythmSong(BaseSong):
 		if len(self.rating) == 0:
 			self.rating = 0
 		else:
-			self.rating = int(self.rating[0].content) * 20
+			self.rating = int(round(float(self.rating[0].content))) * 20
 
 		if len(self.dateadded) == 0:
 			self.dateadded = 0
@@ -91,7 +91,7 @@ class RhythmLibraryParser(BaseLibraryParser):
 		return [RhythmSong(s) for s in allSongNodes]
 
 	def findSongBySize(self, size):
-		matches = self.doc.xpath("//entry[@type='song' and file-size = '" + str(size)  + "']")
+		matches = self.doc.xpathEval("//entry[@type='song' and file-size = '" + str(size)  + "']")
 		matchingsongs = []
 		for match in matches:
 			song = RhythmSong(match)

--- a/iTunesToRhythm.py
+++ b/iTunesToRhythm.py
@@ -76,8 +76,8 @@ def main(argv):
 							print( "\t\t\tModifying destination " + str(source.playcount) + " vs " + str(destination.playcount) )
 							outputModifications = outputModifications + 1
 				else:
-				    outputModifications = outputModifications + 1
-				if options.writeChanges:
+					outputModifications = outputModifications + 1
+				if options.writeChanges and source is not None and destination is not None:
 					if not options.noratings:
 						if destination.rating != source.rating & source.rating > 0:
 							destination.setRating(source.rating)


### PR DESCRIPTION
When syncing between rhythmbox and amarok, I encountered an xpath (xpathEval) error, an error converting fractional ratings (originally from itunes) to an int, and an error when the source or destination objects aren't found. These minor fixes should address all of those problems.