### PR TITLE
Add option to use song titles instead of file sizes for matching songs

### DIFF
--- a/iTunesToRhythm.py
+++ b/iTunesToRhythm.py
@@ -56,7 +56,7 @@ def main(argv):
 				print( "*** UNICODE *** " )
 		if song.size is not None and song.size != "Unknown":
 			# find equivalent itunes song
-			match = correlator.correlateSong(song, options.confirm, options.fastAndLoose,  options.promptForDisambiguate)
+			match = correlator.correlateSong(song, options.confirm, options.fastAndLoose, options.usefilename, options.promptForDisambiguate)
 			# calculate if two way
 			destination = song
 			source = match
@@ -156,6 +156,7 @@ def processCommandLine(argv):
 	parser.add_option("--noratings", action="store_true", dest= "noratings",  default = False,  help = "do not update ratings")
 	parser.add_option("--twoway", action="store_true", dest= "twoway",  default = False,  help = "sync up the two files, giving precedence to the items with the higher playcount")
 	parser.add_option("--dateadded", action="store_true", dest= "dateadded",  default = False,  help = "update dates (only iTunes to Rhythmbox on Linux)")
+	parser.add_option("--usefilename", action="store_true", dest= "usefilename",  default = False,  help = "use file names instead of file sizes to match songs")
 
 	amarokGroup = OptionGroup(parser,  "Amarok options",  "Options for connecting to an Amarok MySQL remote database")
 	amarokGroup.add_option("-s",  "--server",  dest="servername",  help = "host name of the MySQL database server")
@@ -189,9 +190,12 @@ class SongCorrelator(object):
 		self.manuallyResolvedMatches = 0
 
 	# attempt to find matching song in database
-	def correlateSong(self, song, confirm, fastAndLoose,  promptForDisambiguate):
+	def correlateSong(self, song, confirm, fastAndLoose, usefilename, promptForDisambiguate):
 		match = None
-		matches = self.parser.findSongBySize(song.size)
+		if usefilename:	
+			matches = self.parser.findSongByTitle(song.title)
+		else:
+			matches = self.parser.findSongBySize(song.size)
 		if matches is None:
 			matchcount = 0
 		else:

--- a/iTunesToRhythm.py
+++ b/iTunesToRhythm.py
@@ -56,7 +56,7 @@ def main(argv):
 				print( "*** UNICODE *** " )
 		if song.size is not None and song.size != "Unknown":
 			# find equivalent itunes song
-			match = correlator.correlateSong(song, options.confirm, options.fastAndLoose, options.usefilename, options.promptForDisambiguate)
+			match = correlator.correlateSong(song, options.confirm, options.fastAndLoose, options.useSongTitle, options.promptForDisambiguate)
 			# calculate if two way
 			destination = song
 			source = match
@@ -156,7 +156,7 @@ def processCommandLine(argv):
 	parser.add_option("--noratings", action="store_true", dest= "noratings",  default = False,  help = "do not update ratings")
 	parser.add_option("--twoway", action="store_true", dest= "twoway",  default = False,  help = "sync up the two files, giving precedence to the items with the higher playcount")
 	parser.add_option("--dateadded", action="store_true", dest= "dateadded",  default = False,  help = "update dates (only iTunes to Rhythmbox on Linux)")
-	parser.add_option("--usefilename", action="store_true", dest= "usefilename",  default = False,  help = "use file names instead of file sizes to match songs")
+	parser.add_option("--useSongTitle", action="store_true", dest= "useSongTitle",  default = False,  help = "use song titles instead of file sizes to match songs")
 
 	amarokGroup = OptionGroup(parser,  "Amarok options",  "Options for connecting to an Amarok MySQL remote database")
 	amarokGroup.add_option("-s",  "--server",  dest="servername",  help = "host name of the MySQL database server")
@@ -190,9 +190,9 @@ class SongCorrelator(object):
 		self.manuallyResolvedMatches = 0
 
 	# attempt to find matching song in database
-	def correlateSong(self, song, confirm, fastAndLoose, usefilename, promptForDisambiguate):
+	def correlateSong(self, song, confirm, fastAndLoose, useSongTitle, promptForDisambiguate):
 		match = None
-		if usefilename:	
+		if useSongTitle:	
 			matches = self.parser.findSongByTitle(song.title)
 		else:
 			matches = self.parser.findSongBySize(song.size)

--- a/songparser.py
+++ b/songparser.py
@@ -50,5 +50,14 @@ class BaseLibraryParser(object):
 				return results
 				
 	#@abstractmethod
+	def findSongByTitle(self, title):
+		results = []
+		allSongs = self.getSongs()
+		for song in allSongs:
+			if song.title == title:
+				results.append(song)
+				return results
+				
+	#@abstractmethod
 	def save(self):
 		self.doc.saveFile(self.location)


### PR DESCRIPTION
So I uploaded all my library to Google Play Music, then removed my local copy a couple of years ago
This week I decided to download all the library again, and wanted to preserve date added, song punctuation and playcount from an old copy of the Rhythmbox library into my newly imported songs in Rhythmbox, but file size did not match as Google copies must have different quality.
I added the option to use song name instead of file size to match songs, and it worked :+1:  (it may be that songs with same title may have been wrongly identified, perhaps need to add option to match title and artist.