### PR TITLE
added support for last played date

### DIFF
--- a/dumpitunes.py
+++ b/dumpitunes.py
@@ -34,6 +34,7 @@ class iTunesSong(BaseSong):
 		except IndexError:
 			self.filePath = ""
 		self.dateadded = self.xmlNode.xpathEval("date[preceding-sibling::* = 'Date Added']")
+		self.playdate = self.xmlNode.xpathEval("date[preceding-sibling::* = 'Play Date UTC']")
 
 		if len(self.artist) == 0:
 			self.artist = "Unknown"
@@ -65,6 +66,11 @@ class iTunesSong(BaseSong):
 		else:
 		#http://www.epochconverter.com/
 			self.dateadded = int(time.mktime(time.strptime(self.dateadded[0].content, '%Y-%m-%dT%H:%M:%SZ')))
+
+		if len(self.playdate) == 0:
+			self.playdate = 0
+		else:
+			self.playdate = int(time.mktime(time.strptime(self.playdate[0].content, '%Y-%m-%dT%H:%M:%SZ')))
 
 
 	def setRating(self,  rating):
@@ -105,6 +111,19 @@ class iTunesSong(BaseSong):
 			dateaddedValueNode = dateaddedValueNodes[0]
 
 		dateaddedValueNode.setContent(str(dateadded))
+
+	def setPlayDate(self,  playdate):
+		playdateValueNodes = self.xmlNode.xpathEval("integer[preceding-sibling::* = 'Play Date UTC'][1]")
+		if len(playdateValueNodes) == 0:
+			newPlayDateKeyNode = libxml2.newNode("key")
+			self.xmlNode.addChild(newPlayDateKeyNode)
+			newPlayDateKeyNode.setContent("Play Date UTC")
+			playdateValueNode = libxml2.newNode("last-played")
+			newPlayDateKeyNode.addSibling(playdateValueNode)
+		else:
+			playdateValueNode = playdateValueNodes[0]
+
+		playdateValueNode.setContent(str(playdate))
 
 def main(argv):
 	location = argv[1]

--- a/dumprhythm.py
+++ b/dumprhythm.py
@@ -30,6 +30,7 @@ class RhythmSong(BaseSong):
 		self.playcount = self.xmlNode.xpathEval("play-count")
 		self.rating = self.xmlNode.xpathEval("rating")
 		self.dateadded = self.xmlNode.xpathEval("first-seen")[0].content
+		self.playdate = self.xmlNode.xpathEval("last-played")
 
 		if len(self.playcount) == 0:
 			self.playcount = 0
@@ -45,6 +46,11 @@ class RhythmSong(BaseSong):
 			self.dateadded = 0
 		else:
 			self.dateadded = int(self.dateadded)
+
+		if len(self.playdate) == 0:
+			self.playdate = 0
+		else:
+			self.playdate = int(self.playdate)
 
 
 	def setRating(self, rating):
@@ -73,6 +79,15 @@ class RhythmSong(BaseSong):
 			self.xmlNode.addChild(newNode)
 		else:
 			dateaddedNode[0].setContent(str(dateadded))
+
+	def setPlayDate(self, playdate):
+		playdateNode = self.xmlNode.xpathEval("last-played")
+		if len(playdateNode) == 0:
+			newNode = libxml2.newNode("last-played")
+			newNode.setContent(str(playdate))
+			self.xmlNode.addChild(newNode)
+		else:
+			playdateNode[0].setContent(str(playdate))
 
 def main(argv):
 	location = argv[1]

--- a/iTunesToRhythm.py
+++ b/iTunesToRhythm.py
@@ -91,6 +91,11 @@ def main(argv):
 							if destination.dateadded != source.dateadded:
 								destination.setDateAdded(match.dateadded)
 								print( "\t\t\tDate added changed to " + str(source.dateadded) )
+					if options.playdate:
+						if destination.playdate is not None and source.playdate is not None:
+							if destination.playdate != source.playdate:
+								destination.setPlayDate(match.playdate)
+								print( "\t\t\tDate played changed to " + str(source.playdate) )
 
 	# dump summary results
 	print( "\nSummary\n------------------------------------" )
@@ -161,6 +166,7 @@ def processCommandLine(argv):
 	parser.add_option("--noratings", action="store_true", dest= "noratings",  default = False,  help = "do not update ratings")
 	parser.add_option("--twoway", action="store_true", dest= "twoway",  default = False,  help = "sync up the two files, giving precedence to the items with the higher playcount")
 	parser.add_option("--dateadded", action="store_true", dest= "dateadded",  default = False,  help = "update dates (only iTunes to Rhythmbox on Linux)")
+	parser.add_option("--playdate", action="store_true", dest= "playdate",  default = False,  help = "update play dates (only iTunes to Rhythmbox on Linux)")
 	parser.add_option("--useSongTitle", action="store_true", dest= "useSongTitle",  default = False,  help = "use song titles instead of file sizes to match songs")
 
 	amarokGroup = OptionGroup(parser,  "Amarok options",  "Options for connecting to an Amarok MySQL remote database")

--- a/songparser.py
+++ b/songparser.py
@@ -27,6 +27,7 @@ class BaseSong(object):
 		self.playcount = 0
 		self.filePath = ""
 		self.dateadded = 0
+		self.playdate = 0
 
 class BaseLibraryParser(object):
 	def __init__(self, location):


### PR DESCRIPTION
I have used Media Monkey on Windows before and moved on to Manjaro Linux. I could migrate my Media Monkey to Strawberry and now tried my luck with Rhythmbox to. Since all my Smart Playlists depends on Last Played Date, i missed this value in the original version. I have tried to add support for this field. If you now add the option --playdate as parameter, it converts this values additionally to the given fields. Don't know if this is helpful for others to.

At least in my tests, i could export Media Monkey to iTunes and iTunes to Rhythmbox with this addition.